### PR TITLE
Adds support for making URLs into hyperlinks in the video description.

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -272,20 +272,24 @@ function getVideoDescription(videoID) {
             return;
         }
         var description = data.items[0].snippet.description;
-        /* RegEx to match http or https addresses
-        * This will currently only match TLD of two or three letters
-        * Ends capture when:
-        *    (1) it encounters a TLD
-        *    (2) it encounters a period (.) or whitespace, if the TLD was followed by a forwardslash (/) */
-        var re = /((?:http|https)\:\/\/[a-zA-Z0-9\-\.]+.[a-zA-Z]{2,3}(?:\/\S*[^\.\s])?)/g;
-        /* Wraps all found URLs in <a> tags */
-        description = description.replace(re, '<a href="$1" target="_blank">$1</a>');
+        description = highLightURL(description);
         $("#zen-video-description").text(description);
     }).fail(function(jqXHR, textStatus, errorThrown) {
         var responseText = JSON.parse(jqXHR.error().responseText);
         hasError = true;
         showErrorMessage(responseText.error.errors[0].message);
     });
+}
+
+function highLightURL(text) {
+    /* RegEx to match http or https addresses
+    * This will currently only match TLD of two or three letters
+    * Ends capture when:
+    *    (1) it encounters a TLD
+    *    (2) it encounters a period (.) or whitespace, if the TLD was followed by a forwardslash (/) */
+    var re = /((?:http|https)\:\/\/[a-zA-Z0-9\-\.]+.[a-zA-Z]{2,3}(?:\/\S*[^\.\s])?)/g;
+    /* Wraps all found URLs in <a> tags */
+    return text.replace(re, '<a href="$1" target="_blank">$1</a>');
 }
 
 // TODO: this function can go away, the YouTube API will let you play video by URL

--- a/js/everything.js
+++ b/js/everything.js
@@ -271,7 +271,16 @@ function getVideoDescription(videoID) {
             showErrorMessage("Video description not found");
             return;
         }
-        $("#zen-video-description").text(data.items[0].snippet.description);
+        var description = data.items[0].snippet.description;
+        /* RegEx to match http or https addresses
+        * This will currently only match TLD of two or three letters
+        * Ends capture when:
+        *    (1) it encounters a TLD
+        *    (2) it encounters a period (.) or whitespace, if the TLD was followed by a forwardslash (/) */
+        var re = /((?:http|https)\:\/\/[a-zA-Z0-9\-\.]+.[a-zA-Z]{2,3}(?:\/\S*[^\.\s])?)/g;
+        /* Wraps all found URLs in <a> tags */
+        description = description.replace(re, '<a href="$1" target="_blank">$1</a>');
+        $("#zen-video-description").text(description);
     }).fail(function(jqXHR, textStatus, errorThrown) {
         var responseText = JSON.parse(jqXHR.error().responseText);
         hasError = true;

--- a/js/everything.js
+++ b/js/everything.js
@@ -272,8 +272,8 @@ function getVideoDescription(videoID) {
             return;
         }
         var description = data.items[0].snippet.description;
-        description = highLightURL(description);
-        $("#zen-video-description").text(description);
+        description = anchorURLs(description);
+        $("#zen-video-description").html(description);
     }).fail(function(jqXHR, textStatus, errorThrown) {
         var responseText = JSON.parse(jqXHR.error().responseText);
         hasError = true;
@@ -281,13 +281,13 @@ function getVideoDescription(videoID) {
     });
 }
 
-function highLightURL(text) {
+function anchorURLs(text) {
     /* RegEx to match http or https addresses
     * This will currently only match TLD of two or three letters
     * Ends capture when:
     *    (1) it encounters a TLD
     *    (2) it encounters a period (.) or whitespace, if the TLD was followed by a forwardslash (/) */
-    var re = /((?:http|https)\:\/\/[a-zA-Z0-9\-\.]+.[a-zA-Z]{2,3}(?:\/\S*[^\.\s])?)/g;
+    var re = /((?:http|https)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(?:\/\S*[^\.\s])?)/g;
     /* Wraps all found URLs in <a> tags */
     return text.replace(re, '<a href="$1" target="_blank">$1</a>');
 }


### PR DESCRIPTION
Currently the RegEx will only recognize TLD of two or three characters. It covers most cases, but not all.
Fixes #66