### PR TITLE
Makes request for search auto completion go over https

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -553,7 +553,7 @@ $(function() {
         minLength: 1
     }, {
         source: function (query, processSync, processAsync) {
-            return $.getJSON("http://suggestqueries.google.com/complete/search?callback=?", {
+            return $.getJSON("https://suggestqueries.google.com/complete/search?callback=?", {
                 q: query,
                 client: "youtube",
                 ds: "yt"

--- a/js/everything.js
+++ b/js/everything.js
@@ -353,7 +353,7 @@ function updateTweetMessage() {
 
 // Takes seconds as a Number, returns a : delimited string
 function cleanTime(time) {
-    // Awesome hack for int->double cast http://stackoverflow.com/a/8388831/2785681
+    // Awesome hack for int->double cast https://stackoverflow.com/a/8388831/2785681
     var t = ~~time;
 
     var seconds = t % 60;

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@ var Browser = require("zombie");
 var path = require("path");
 var fs = require("fs");
 
+var _js = "";
+
 const browser = new Browser();
 
 var indexHTMLURL = "file://" + path.join(__dirname, "..", "index.html");
@@ -101,6 +103,10 @@ describe("Page Structure", function () {
 });
 
 describe("JavaScript components", function() {
+    before(function () {
+        _js = fs.readFileSync(path.join(__dirname, "../js", "everything.js"), "utf8");
+    });
+
     it("should load TrackJS token", function() {
         var trackjs = browser.evaluate("window._trackJs");
         assert.strictEqual(Object.keys(trackjs).length, 1);
@@ -116,6 +122,9 @@ describe("JavaScript components", function() {
     });
     it("should load ZenPlayer from everything.js", function() {
         assert.ok(browser.evaluate("ZenPlayer"));
+    });
+    it("should make all requests over https, not http", function() {
+        assert.strictEqual(-1, _js.indexOf("http://", "Please use HTTPS for all scripts"));
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -124,7 +124,7 @@ describe("JavaScript components", function() {
         assert.ok(browser.evaluate("ZenPlayer"));
     });
     it("should make all requests over https, not http", function() {
-        assert.strictEqual(-1, _js.indexOf("http://", "Please use HTTPS for all scripts"));
+        assert.strictEqual(-1, _js.indexOf("http://"), "Please use HTTPS for all scripts");
     });
 });
 


### PR DESCRIPTION
Browsers will block scripts from making http request when a site is accessed via https. Therefore the auto completion did not work on https. This fixes it.