### PR TITLE
Fix tests commented out from redesign #164

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -70,14 +70,14 @@ describe("Page Structure", function () {
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-453.png");
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-905.png");
         assert.equal(browser.query("header > figure > a").href, "https://zenplayer.audio/");
-        assert.ok(browser.query("header > figure > a > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);
-        assert.equal(browser.query("header > figure > a > img.img-100").alt, "Zen Audio Player logo");
+        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);
+        assert.equal(browser.query("header > figure > a.zen-logo > img.img-100").alt, "Zen Audio Player logo");
     });
     it("should have expected elements", function () {
         assert.ok(browser.query("header"), "Couldn't find header");
         assert.ok(browser.query("header > figure"), "Couldn't find <header><figure>");
         assert.ok(browser.query("header > figure > a"), "Couldn't find <header><figure><a>");
-        assert.ok(browser.query("header > figure > a > img.img-100"), "Couldn't find <header><figure><a><img>");
+        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100"), "Couldn't find <header><figure><a><img>");
         assert.ok(browser.query("#form"), "Couldn't find #form");
         // TODO: validate the rest of the form
         assert.ok(browser.query("#demo"), "Couldn't find #demo");
@@ -89,9 +89,9 @@ describe("Page Structure", function () {
         assert.ok(browser.query("#v"), "Couldn't find #v");
 
         assert.ok(browser.query("footer"), "Couldn't find footer");
-        assert.ok(browser.query("footer > div.color-grey > p"), "Couldn't find footer<p>Created by");
-        assert.ok(browser.query("footer > div.color-grey > p ~ p"), "Couldn't find footer<p>Created by...</p><p>");
-        assert.ok(browser.query("footer > div.color-grey > p ~ p ~ p"), "Couldn't find footer<p>Created by...</p><p>Source available...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p"), "Couldn't find footer > div.color-grey <p>Created by");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>Source available...</p><p>");
     });
     it("should not have strange HTML elements", function () {
         // These are more of a sanity check than anything else

--- a/test/index.js
+++ b/test/index.js
@@ -70,14 +70,14 @@ describe("Page Structure", function () {
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-453.png");
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-905.png");
         assert.equal(browser.query("header > figure > a").href, "https://zenplayer.audio/");
-        // assert.ok(browser.query("header > figure > a > img.logo").src.indexOf("img/zen-audio-player-905.png") !== -1);
-        // assert.equal(browser.query("header > figure > a > img.logo").alt, "Zen Audio Player logo");
+        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);
+        assert.equal(browser.query("header > figure > a.zen-logo > img.img-100").alt, "Zen Audio Player logo");
     });
     it("should have expected elements", function () {
         assert.ok(browser.query("header"), "Couldn't find header");
         assert.ok(browser.query("header > figure"), "Couldn't find <header><figure>");
         assert.ok(browser.query("header > figure > a"), "Couldn't find <header><figure><a>");
-        // assert.ok(browser.query("header > figure > a > img.logo"), "Couldn't find <header><figure><a><img>");
+        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100"), "Couldn't find <header><figure><a><img>");
         assert.ok(browser.query("#form"), "Couldn't find #form");
         // TODO: validate the rest of the form
         assert.ok(browser.query("#demo"), "Couldn't find #demo");
@@ -89,9 +89,9 @@ describe("Page Structure", function () {
         assert.ok(browser.query("#v"), "Couldn't find #v");
 
         assert.ok(browser.query("footer"), "Couldn't find footer");
-        // assert.ok(browser.query("footer > p"), "Couldn't find footer<p>Created by");
-        // assert.ok(browser.query("footer > p ~ p"), "Couldn't find footer<p>Created by...</p><p>");
-        // assert.ok(browser.query("footer > p ~ p ~ p"), "Couldn't find footer<p>Created by...</p><p>Source available...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p"), "Couldn't find footer > div.color-grey <p>Created by");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>Source available...</p><p>");
     });
     it("should not have strange HTML elements", function () {
         // These are more of a sanity check than anything else

--- a/test/index.js
+++ b/test/index.js
@@ -70,14 +70,14 @@ describe("Page Structure", function () {
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-453.png");
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-905.png");
         assert.equal(browser.query("header > figure > a").href, "https://zenplayer.audio/");
-        // assert.ok(browser.query("header > figure > a > img.logo").src.indexOf("img/zen-audio-player-905.png") !== -1);
-        // assert.equal(browser.query("header > figure > a > img.logo").alt, "Zen Audio Player logo");
+        assert.ok(browser.query("header > figure > a > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);
+        assert.equal(browser.query("header > figure > a > img.img-100").alt, "Zen Audio Player logo");
     });
     it("should have expected elements", function () {
         assert.ok(browser.query("header"), "Couldn't find header");
         assert.ok(browser.query("header > figure"), "Couldn't find <header><figure>");
         assert.ok(browser.query("header > figure > a"), "Couldn't find <header><figure><a>");
-        // assert.ok(browser.query("header > figure > a > img.logo"), "Couldn't find <header><figure><a><img>");
+        assert.ok(browser.query("header > figure > a > img.img-100"), "Couldn't find <header><figure><a><img>");
         assert.ok(browser.query("#form"), "Couldn't find #form");
         // TODO: validate the rest of the form
         assert.ok(browser.query("#demo"), "Couldn't find #demo");
@@ -89,9 +89,9 @@ describe("Page Structure", function () {
         assert.ok(browser.query("#v"), "Couldn't find #v");
 
         assert.ok(browser.query("footer"), "Couldn't find footer");
-        // assert.ok(browser.query("footer > p"), "Couldn't find footer<p>Created by");
-        // assert.ok(browser.query("footer > p ~ p"), "Couldn't find footer<p>Created by...</p><p>");
-        // assert.ok(browser.query("footer > p ~ p ~ p"), "Couldn't find footer<p>Created by...</p><p>Source available...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p"), "Couldn't find footer<p>Created by");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p"), "Couldn't find footer<p>Created by...</p><p>");
+        assert.ok(browser.query("footer > div.color-grey > p ~ p ~ p"), "Couldn't find footer<p>Created by...</p><p>Source available...</p><p>");
     });
     it("should not have strange HTML elements", function () {
         // These are more of a sanity check than anything else

--- a/test/index.js
+++ b/test/index.js
@@ -70,14 +70,14 @@ describe("Page Structure", function () {
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-453.png");
         assert.ok(fs.existsSync(imgFolderPath) + "zen-audio-player-905.png");
         assert.equal(browser.query("header > figure > a").href, "https://zenplayer.audio/");
-        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);
-        assert.equal(browser.query("header > figure > a.zen-logo > img.img-100").alt, "Zen Audio Player logo");
+        // assert.ok(browser.query("header > figure > a > img.logo").src.indexOf("img/zen-audio-player-905.png") !== -1);
+        // assert.equal(browser.query("header > figure > a > img.logo").alt, "Zen Audio Player logo");
     });
     it("should have expected elements", function () {
         assert.ok(browser.query("header"), "Couldn't find header");
         assert.ok(browser.query("header > figure"), "Couldn't find <header><figure>");
         assert.ok(browser.query("header > figure > a"), "Couldn't find <header><figure><a>");
-        assert.ok(browser.query("header > figure > a.zen-logo > img.img-100"), "Couldn't find <header><figure><a><img>");
+        // assert.ok(browser.query("header > figure > a > img.logo"), "Couldn't find <header><figure><a><img>");
         assert.ok(browser.query("#form"), "Couldn't find #form");
         // TODO: validate the rest of the form
         assert.ok(browser.query("#demo"), "Couldn't find #demo");
@@ -89,9 +89,9 @@ describe("Page Structure", function () {
         assert.ok(browser.query("#v"), "Couldn't find #v");
 
         assert.ok(browser.query("footer"), "Couldn't find footer");
-        assert.ok(browser.query("footer > div.color-grey > p"), "Couldn't find footer > div.color-grey <p>Created by");
-        assert.ok(browser.query("footer > div.color-grey > p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>");
-        assert.ok(browser.query("footer > div.color-grey > p ~ p ~ p"), "Couldn't find footer > div.color-grey<p>Created by...</p><p>Source available...</p><p>");
+        // assert.ok(browser.query("footer > p"), "Couldn't find footer<p>Created by");
+        // assert.ok(browser.query("footer > p ~ p"), "Couldn't find footer<p>Created by...</p><p>");
+        // assert.ok(browser.query("footer > p ~ p ~ p"), "Couldn't find footer<p>Created by...</p><p>Source available...</p><p>");
     });
     it("should not have strange HTML elements", function () {
         // These are more of a sanity check than anything else


### PR DESCRIPTION
### Motivation and Context
- [x] Why is this change required? What problem does it solve? 
Closes #164
- [x] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.
As per the changes in #155, I changed the commented tests in the following manner:
If the commented test was

`assert.ok(browser.query("header > figure > a > img.logo").src.indexOf("img/zen-audio-player-905.png") !== -1);`

and I saw that the class of header > figure > a > img was changed in #155 from 'logo' to 'img-100' and that `<a href="https://zenplayer.audio/" title="Zen Audio Player">` was changed to `<a href="https://zenplayer.audio/" title="Zen Audio Player" class="zen-logo">` I changed the test to 

`assert.ok(browser.query("header > figure > a.zen-logo > img.img-100").src.indexOf("img/zen-audio-player-905.png") !== -1);`

Also `footer > p` `footer > p ~ p` and `footer > p ~ p ~p` were moved inside `footer > div.color-grey`.

I changed the 6 commented tests in the same manner and un-commented them.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.