### PR TITLE
Adds the first piece of #170

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "main": "tests.js",
   "scripts": {
     "lint:js": "eslint js/*.js",
-    "lint:tests":"eslint test/*.js",
+    "lint:tests": "eslint test/*.js",
     "lint:html": "htmlhint index.html",
     "lint:css": "csslint --format=compact --warnings=box-model,ids css/*.css",
     "stylelint:css": "stylelint css/*.css",
     "lint": "npm run lint:js && npm run lint:html && npm run lint:css && npm run lint:tests",
     "pretest": "npm run stylelint:css && npm run lint",
     "test": "mocha",
-    "exp-fix:js": "eslint js/everything.js --fix"
+    "exp-fix:js": "eslint js/everything.js --fix",
+    "start": "http-server --cors -o -a localhost"
   },
   "repository": {
     "type": "git",
@@ -40,5 +41,8 @@
   },
   "engines": {
     "node": ">=4.x"
+  },
+  "dependencies": {
+    "http-server": "^0.9.0"
   }
 }


### PR DESCRIPTION
After you run `npm install`, you can now run `npm start` and a webpage will open with the site running as if it were live! 

The only drawback with this simple solution is the webpage will not reload automatically when any of the files change. The workaround is to just manually reload the page in the browser.

Closes #170 