### PR TITLE
Closes issue #222.  Autoplay of suggested next video. Button toggle.  Does not play duplicates by maintaining history of all videos.

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
                 <button class="btn" id="toggleDescription">
                     Show Description
                 </button>
+                <button class="btn" id="toggleAutoplay">
+                    Autoplay
+                </button>
             </div>
 
             <!-- Plyr controls' icons and Plyr player itself -->

--- a/js/everything.js
+++ b/js/everything.js
@@ -64,9 +64,6 @@ var currentVideoID;
 var playList = [];
 var autoplayState;
 
-
-
-
 var errorMessage = {
     init: function() {
         // nothing for now
@@ -218,7 +215,7 @@ var ZenPlayer = {
                 that.show();
                 updateTweetMessage();
             });
-			// when player has finished playing
+            // when player has finished playing
             plyrPlayer.addEventListener("ended", function() {
                 if (autoplayState !== null && autoplayState === "true") {
                     plyrPlayer.removeEventListener("ended");
@@ -251,12 +248,8 @@ var ZenPlayer = {
                                 }
                             }
 					// nothing to be played if empty playlist
-                            if (playList.length === 0)
+                            if (playList.length !== 0)
                             {
-                                newId = null;
-                            }
-                            else {
-								// write 'history' dict to storage
                                 idMap[newId] = true;
                                 window.sessionStorage.setItem("idMap", JSON.stringify(idMap));
                             }
@@ -580,32 +573,32 @@ $(function() {
     // How do we know if the value is truly invalid?
     // Preload the form from the URL
     var currentVideoID = getCurrentVideoID();
-    if (currentVideoID) {
+    if (currentVideoID)
+    {
         $("#v").attr("value", currentVideoID);
                             // get similar videos, populate playList
-        $.ajax({
-            url: "https://www.googleapis.com/youtube/v3/search",
-            dataType: "json",
-            async: false,
-            data: {
-                key: youTubeDataApiKey,
-                part: "snippet",
-                type: "video",
-                relatedToVideoId: currentVideoID
-            },
-            success: function(data) {
-				// push items into playlist
-                for (var i = 0;i < data.items.length;i ++ )
-				{
-                    playList.push(data.items[i].id.videoId);
+        if (!isFileProtocol()) {
+            $.ajax({
+                url: "https://www.googleapis.com/youtube/v3/search",
+                dataType: "json",
+                async: false,
+                data: {
+                    key: youTubeDataApiKey,
+                    part: "snippet",
+                    type: "video",
+                    relatedToVideoId: currentVideoID
+                },
+                success: function(data) {
+                    // push items into playlist
+                    for (var i = 0;i < data.items.length;i ++ )
+                    {
+                        playList.push(data.items[i].id.videoId);
+                    }
                 }
-            }
-        }).fail(function(jqXHR, textStatus, errorThrown) {
-            logError(jqXHR, textStatus, errorThrown, "Lookup error");
-        });
-
-
-
+            }).fail(function(jqXHR, textStatus, errorThrown) {
+                logError(jqXHR, textStatus, errorThrown, "Lookup error");
+            });
+        }
     }
     else {
         var currentSearchQuery = getCurrentSearchQuery();

--- a/js/everything.js
+++ b/js/everything.js
@@ -219,35 +219,35 @@ var ZenPlayer = {
             plyrPlayer.addEventListener("ended", function() {
                 if (autoplayState !== null && autoplayState === "true") {
                     plyrPlayer.removeEventListener("ended");
-					/*
-					 idMap is dict- history of all songs played till now, of the form
-					 <key=videoId>: <value=true>. It is stored in the session storage of the
-					 browser. When the player has finished playing, the last entry from the playlist
-					 is picked as a possible candidate and checked for presence in idMap. If its present ie its
-					 already been played, we pop() and get the new last entry from playlist, looking for a new song. Whatever
-					 is a valid new entry gets added to the dict which is then written to session storage again
-					*/
-					// if playList songs left
+                    /*
+                    idMap is dict- history of all songs played till now, of the form
+                    <key=videoId>: <value=true>. It is stored in the session storage of the
+                    browser. When the player has finished playing, the last entry from the playlist
+                    is picked as a possible candidate and checked for presence in idMap. If its present ie its
+                    already been played, we pop() and get the new last entry from playlist, looking for a new song. Whatever
+                    is a valid new entry gets added to the dict which is then written to session storage again
+                    */
+                    // if playList songs left
                     if (playList.length !== 0)
-					{
-						// get autoplay candidate from playlist
+                    {
+                        // get autoplay candidate from playlist
                         var newId = playList[playList.length - 1];
-						// load 'history' dict from storage
+                        // load 'history' dict from storage
                         var idMap  = window.sessionStorage.getItem("idMap");
                         idMap = JSON.parse(idMap);
                         // first time?
                         if (idMap !== null && newId !== "")
-						{
+                        {
                             // keep popping till unique next song found
                             while ( (newId in idMap) && (playList.length !== 0))
-							{
+                            {
                                 playList.pop();
                                 if (playList.length >= 1)
                                 {
                                     newId = playList[playList.length - 1];
                                 }
                             }
-					// nothing to be played if empty playlist
+                        // nothing to be played if empty playlist
                             if (playList.length !== 0)
                             {
                                 idMap[newId] = true;
@@ -341,23 +341,23 @@ var ZenPlayer = {
         });
     },
     setupAutoplayToggle: function()
-	{
-		// toggle auto next song playing
+    {
+        // toggle auto next song playing
         $("#toggleAutoplay").click(function(event)
-		{
+        {
             var toggleTextElement = $("#" + event.currentTarget.id);
             if (autoplayState === null)
-			{
+            {
                 autoplayState = "true";
                 toggleTextElement.text("Stop autoplay");
             }
             else {
                 if (autoplayState === "true")
-				{
+                {
                     toggleTextElement.text("Start autoplay");
                     autoplayState = "false";
                 }
-				else {
+                else {
                     toggleTextElement.text("Stop autoplay");
                     autoplayState = "true";
                 }
@@ -560,9 +560,9 @@ $(function() {
     errorMessage.init();
     autoplayState = window.sessionStorage.getItem("autoplayState");
     if (autoplayState !== null)
-	{
+    {
         if (autoplayState === "true")
-		{
+        {
             $("#toggleAutoplay").text("Stop autoplay");
         }
         else {

--- a/js/everything.js
+++ b/js/everything.js
@@ -259,7 +259,7 @@ var ZenPlayer = {
                             idMap[newId] = true;
                             window.sessionStorage.setItem("idMap", JSON.stringify(idMap));
                         }
-						// play the new song from autoplay
+                        // play the new song from autoplay
                         that.playNext(newId);
                     }
                 }

--- a/js/everything.js
+++ b/js/everything.js
@@ -376,6 +376,7 @@ var ZenPlayer = {
         var description = "";
 
         if (isFileProtocol()) {
+            console.log("Skipping video description request as we're running the site locally.");
             $("#toggleDescription").hide();
         }
         else {
@@ -433,9 +434,10 @@ function updateTweetMessage() {
     );
 }
 
-function logError(jqXHR, textStatus, errorThrown, errorMessage) {
+function logError(jqXHR, textStatus, errorThrown, _errorMessage) {
     var responseText = JSON.parse(jqXHR.error().responseText);
     errorMessage.show(responseText.error.errors[0].message);
+    console.log(_errorMessage, errorThrown);
 }
 
 function toggleElement(event, toggleID, buttonText) {


### PR DESCRIPTION
Provide a general summary of your changes in the **Title** above.
### Important

Mark with [x] to select. Leave as [ ] to unselect.
### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.
  Closes #222 
### Types of changes

What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
### Description
- [ ] Describe your changes in detail.
  Added an autoplay button with two states - 'start autoplay' and 'stop autoplay'. With autoplay ON, similar videos keep playing one after the other. 'stop autoplay' disables this feature.  History of videos played till now is stored and accessed from local session storage.
### Final checklist:

Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [ ] All tests passed.

Last two tests "Demo" and "Form" fail - they complain about actions performed on null DOM objects.  Maybe it has something to do with the order the player components and the page itself are loaded. The Demo still works, if the button is clicked manually.  
