### PR TITLE
Fixed the Video ID Parse. Issue #225

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -368,7 +368,7 @@ function toggleElement(event, toggleID, buttonText) {
 function getCurrentVideoID() {
     var v = getParameterByName(window.location.search, "v");
     // If the URL had 2 v parameters, try parsing the second (usually when ?v=someurl&v=xyz)
-    var vParams = window.location.search.match(/v=\w+/g);
+    var vParams = window.location.search.match(/v=\w+\-+/g);
     if (vParams && vParams.length > 1) {
         v = vParams[vParams.length - 1].replace("v=", "");
     }


### PR DESCRIPTION
Fixed the bug. Now, the video ID will parse correctly when inserting into the URL as in this example:

https://zenplayer.audio/?v=https://www.youtube.com/watch?v=UAWcs5H-qgQ