### PR TITLE
WIP: reverts to Home when form is empty 

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -651,6 +651,11 @@ $(function() {
         $("#demo").hide();
     }
 
+    // Reverts to Home when there is no text in input
+    if ($(".tt-menu").hasClass("tt-empty")) {
+        $(".tt-menu > .tt-dataset").hide();
+    }
+
     // Handle demo link click
     $("#demo").click(function(event) {
         event.preventDefault();


### PR DESCRIPTION
Hey!  It should work, but please let me know if you encounter any flaws.  

I am targeting typeahead.js default classes since I didn’t want to create any new classes and there weren’t any noticeable attributes or properties to attach to.  Using simple jQuery that you have in the document, the suggestions should hide when there isn’t text in the form.

However, when I tried to test locally, I was unable to retrieve any data through the API.  I am unsure as to whether it is a problem with my text editor, my local environment, or pizza fairies, but the main reason that I am stating this is because:
I was unable to test it.

So, that is why I’ve been using the word “should”.  

Anyways, just let me know if there is anything to be fixed!