### PR TITLE
Fix video resume

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -193,6 +193,9 @@ var ZenPlayer = {
                 if (window.sessionStorage && window.sessionStorage.hasOwnProperty(videoID)) {
                     var resumeTime = window.sessionStorage[videoID];
                     var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                    if (videoDuration === 0) {
+                        return;
+                    }
                     if (!isNaN(resumeTime) && resumeTime < videoDuration - 3) {
                         plyrPlayer.plyr.embed.seekTo(resumeTime);
                     }
@@ -223,6 +226,9 @@ var ZenPlayer = {
                 if (window.sessionStorage) {
                     var currentTime = plyrPlayer.plyr.embed.getCurrentTime();
                     var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                    if (videoDuration === 0) {
+                        return;
+                    }
 
                     // Only store the current time if the video isn't done
                     // playing yet. If the video finished already, then it


### PR DESCRIPTION
The fix solves the problem of resuming video from where we left it. 

### Motivation and Context
- [x] Previously it didn't work because videoDuration variable was initiated with 0. I guess that's because of differences in API loading speed (plyr started playing before all information from youtube arrived, in this case videoDuration option).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue). Just added two lines of code that make the player not to start before videoDuration option arrives from youtube.


### Description
- [x] When videoDuration option is got with `var videoDuration = plyrPlayer.plyr.embed.getDuration();` next follows a simple piece of code `if (videoDuration === 0) { return; }`

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.