### PR TITLE
Start with youtube time

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -185,17 +185,14 @@ var ZenPlayer = {
             });
 
             plyrPlayer.addEventListener("playing", function() {
-                if (that.updated) {
+                var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                if (that.updated || videoDuration === 0) {
                     return;
                 }
 
                 // Start video from where we left off, if it makes sense
                 if (window.sessionStorage && window.sessionStorage.hasOwnProperty(videoID)) {
                     var resumeTime = window.sessionStorage[videoID];
-                    var videoDuration = plyrPlayer.plyr.embed.getDuration();
-                    if (videoDuration === 0) {
-                        return;
-                    }
                     if (!isNaN(resumeTime) && resumeTime < videoDuration - 3) {
                         plyrPlayer.plyr.embed.seekTo(resumeTime);
                     }
@@ -223,13 +220,9 @@ var ZenPlayer = {
             plyrPlayer.addEventListener("timeupdate", function() {
                 // Store the current time of the video.
                 var resumeTime = 0;
-                if (window.sessionStorage) {
+                var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                if (window.sessionStorage && videoDuration > 0) {
                     var currentTime = plyrPlayer.plyr.embed.getCurrentTime();
-                    var videoDuration = plyrPlayer.plyr.embed.getDuration();
-                    if (videoDuration === 0) {
-                        return;
-                    }
-
                     // Only store the current time if the video isn't done
                     // playing yet. If the video finished already, then it
                     // should start off at the beginning next time.
@@ -618,7 +611,7 @@ $(function() {
     $("#form").submit(function(event) {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
-        var formValueTime = /[?&]t=(\d*)$/g.exec(formValue);
+        var formValueTime = /[?&]t=(\d*)/g.exec(formValue);
         if (formValueTime && formValueTime.length > 1) {
             formValueTime = parseInt(formValueTime[1], 10);
             formValue = formValue.replace(/&t=\d*$/g, "");

--- a/js/everything.js
+++ b/js/everything.js
@@ -193,6 +193,9 @@ var ZenPlayer = {
                 if (window.sessionStorage && window.sessionStorage.hasOwnProperty(videoID)) {
                     var resumeTime = window.sessionStorage[videoID];
                     var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                    if (videoDuration === 0) {
+                        return;
+                    }
                     if (!isNaN(resumeTime) && resumeTime < videoDuration - 3) {
                         plyrPlayer.plyr.embed.seekTo(resumeTime);
                     }
@@ -223,6 +226,9 @@ var ZenPlayer = {
                 if (window.sessionStorage) {
                     var currentTime = plyrPlayer.plyr.embed.getCurrentTime();
                     var videoDuration = plyrPlayer.plyr.embed.getDuration();
+                    if (videoDuration === 0) {
+                        return;
+                    }
 
                     // Only store the current time if the video isn't done
                     // playing yet. If the video finished already, then it

--- a/js/everything.js
+++ b/js/everything.js
@@ -618,7 +618,7 @@ $(function() {
     $("#form").submit(function(event) {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
-        var formValueTime = /&t=(\d*)$/g.exec(formValue);
+        var formValueTime = /[?&]t=(\d*)$/g.exec(formValue);
         if (formValueTime && formValueTime.length > 1) {
             formValueTime = parseInt(formValueTime[1], 10);
             formValue = formValue.replace(/&t=\d*$/g, "");


### PR DESCRIPTION
This fix is about to start the playing time from the place it was on YouTube video when we left.

### Motivation and Context
- [x] The change is required because YouTube today gives time option with `?t=` but the code works only with `&t=`. Now it works with both.
- [x] This fix is based on my previous commit which is "Fix video resume". That one fixes the problem of resuming video from where we left in on zenplayer.audio.


### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Changed the line `var formValueTime = /&t=(\d*)$/g.exec(formValue);` to `var formValueTime = /[?&]t=(\d*)$/g.exec(formValue);` The changes are at the very beginning of the RegExp (`&t` is replaced with `[?&]t`)
- [x] Added two similar pieces of code `if (videoDuration === 0) { return; }` after videoDuration variable is initiated with `var videoDuration = plyrPlayer.plyr.embed.getDuration();` This change is required because previously the videoDuration variable was initiating with 0 most of the time. My guess about that problem is different loading speed of APIs. When plyr API starts playing the YouTube API still haven't got all required options (like videoDuration in the case).
  

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.