### PR TITLE
Fix video resume

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -173,7 +173,8 @@ var ZenPlayer = {
                 // Updates the time position by a given argument in URL
                 // IE https://zenplayer.audio/?v=koJv-j1usoI&t=30 starts at 0:30
                 var t = getCurrentTimePosition();
-                if (t) {
+                // If played for the first time during session and there's 't' option in query
+                if (t && window.sessionStorage[videoID] === undefined) {
                     that.videoPosition = t;
                     window.sessionStorage[videoID] = t;
                 }
@@ -641,6 +642,8 @@ $(function() {
                         else {
                             window.location.href = makeListenURL(videoID, formValueTime);
                         }
+                        // Hold value for resume time from the argument in URL
+                        window.sessionStorage[videoID] = formValueTime;
                     }
                 }).fail(function(jqXHR, textStatus, errorThrown) {
                     logError(jqXHR, textStatus, errorThrown, "Lookup error");


### PR DESCRIPTION
### Motivation and Context
The problem was that video always started from the time argument in URL.
Now video starts from where we left off. But updates the time position by a given argument in URL if loaded for the first time during the session or if the form was submitted again.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
I've read the code and found out that my change is going to help it work as it was meant to according to it's logic. According to the code we want to resume video from where we left off during the session. Previously video always resumed from time argument in URL. I've fixed that. But then found out that if I want to submit form with the same video but some other time argument the app wouldn't do it and simply resume video from where left off. So I've added a line of code to 'form submission' part to make it update session storage value with the time argument from passed URL. So, that's it. I hope now it works correctly together with some accepted previous commits.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.