### PR TITLE
Issue/#248

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -657,6 +657,13 @@ $(function() {
         $("#demo").hide();
     }
 
+    // Reverts to Home when there is no text in input
+    $("#v").on("input", function() {
+        if ($("#v").val() === "") {
+            $("#search-results").hide();
+        }
+    });
+
     $("input[name='toggleRepeat']").change(function() {
         ZenPlayer.isRepeat = $(this).is(":checked");
     });


### PR DESCRIPTION
#248: Return to "Home" when input is deleted

### Motivation and Context
- [x] I see that nothing happens for months with pull request #249, so I suggest my fix for the problem.
- [x] `Closes #248`

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
I've put an event handler on input. When the input value is an empty string than we just hide "search-results" with JQuery ".hide()". Works perfectly fine on local.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.