### PR TITLE
Closes Issue #222: Autoplay Feature from Youtube

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
                 <button class="btn" id="toggleDescription">
                     Show Description
                 </button>
+                <button class="btn" id="toggleAutoplay">
+                    Autoplay
+                </button>    
                 <input id="toggleRepeat" name="toggleRepeat" type="checkbox" />
                 <label id="toggleRepeatLabel" for="toggleRepeat">Repeat track</label>
             </div>


### PR DESCRIPTION
### Motivation and Context
There's a pull request (#231) but it isn't active for a long time. So I've used that pull request and made some work with it to close the issue #222.
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Cleaned up the code from pull request #231.
    Then fixed some bugs:
    (1) Fixed getNewVideoID function. Previously it just popped up all
    the playList and left only the first element. And if this element
    would be current video id then nextId will be set to null. Now I've
    made a reverse for playlist array to get just the same next video from
    YouTube as Youtube suggests itself and that is done with no further
    changes in the code. I've also removed the while loop from
    getNewVideoID function and that gives the code an opportunity
    to check all the playlist for a next track during the session.
    (2) Fixed the problem when tracks were added to videoMetadata["items"]
    when they were already there. Now there is a clause that checks if
    current track has already been played and if so just doesn't add
    a duplicate.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.