### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Create a bookmark with `javascript: (function () { window.location.href = 'https
 2. Name your bookmark.  
 3. Click on "Edit".  
 4. Paste
-```
-javascript: (function () { window.location.href = 'https://zenplayer.audio/?v=' + location.href; }());
-```
-in the URL field.  
+    ```
+    javascript: (function () { window.location.href = 'https://zenplayer.audio/?v=' + location.href; }());
+    ```
+    in the URL field.  
 5. Click on "Save".  
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Create a bookmark with `javascript: (function () { window.location.href = 'https
 1. Click on a star at the right side of the omnibox (you can also press Ctrl+D (CMD+D on Mac) or choose "Bookmark this page..." from the menu).  
 2. Name your bookmark.  
 3. Click on "Edit".  
-4. Paste
+4. Paste the following snippet into the URL field
     ```
     javascript: (function () { window.location.href = 'https://zenplayer.audio/?v=' + location.href; }());
     ```
-    in the URL field.  
 5. Click on "Save".  
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Create a bookmark with `javascript: (function () { window.location.href = 'https
 1. Click on a star at the right side of the omnibox (you can also press Ctrl+D (CMD+D on Mac) or choose "Bookmark this page..." from the menu).  
 2. Name your bookmark.  
 3. Click on "Edit".  
-4. Paste `javascript: (function () { window.location.href = 'https://zenplayer.audio/?v=' + location.href; }());` in the URL field.  
+4. Paste
+```
+javascript: (function () { window.location.href = 'https://zenplayer.audio/?v=' + location.href; }());
+```
+in the URL field.  
 5. Click on "Save".  
 
 ## Demo


### PR DESCRIPTION
Makes the **JS code** used for bookmarking **easy to copy**

### NEED
- while selecting the JS code from readme it takes time to move the cursor from one line to another accurately

### Types of changes
To make copying the code simpler:
- the code is put into one line in "how to bookmark" section

### Description
- Earlier the cursor needs to be dragged from one line to another. Now by just double-clicking on any part of the code it is selected all at once making it simpler to copy from Readme and use it bookmark edit.

