### PR TITLE
Fix security vulnerability with ecstatic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,11 +132,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "async": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-      "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -549,7 +544,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -660,17 +654,6 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
-      }
-    },
-    "ecstatic": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-1.4.1.tgz",
-      "integrity": "sha1-Mst7b6LikNWGaGdNEV6PDD1WfWo=",
-      "requires": {
-        "he": "0.5.0",
-        "mime": "1.4.1",
-        "minimist": "1.2.0",
-        "url-join": "1.1.0"
       }
     },
     "electron-to-chromium": {
@@ -1185,11 +1168,6 @@
         "sntp": "2.0.2"
       }
     },
-    "he": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
-    },
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
@@ -1295,18 +1273,56 @@
       }
     },
     "http-server": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.9.0.tgz",
-      "integrity": "sha1-jxsGvcczYY1NxCgxx7oa/04GABo=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz",
+      "integrity": "sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=",
       "requires": {
         "colors": "1.0.3",
         "corser": "2.0.1",
-        "ecstatic": "1.4.1",
+        "ecstatic": "2.2.1",
         "http-proxy": "1.16.2",
         "opener": "1.4.3",
         "optimist": "0.6.1",
-        "portfinder": "0.4.0",
+        "portfinder": "1.0.13",
         "union": "0.4.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "ecstatic": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+          "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
+          "requires": {
+            "he": "1.1.1",
+            "mime": "1.4.1",
+            "minimist": "1.2.0",
+            "url-join": "2.0.2"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+          "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+          "requires": {
+            "async": "1.5.2",
+            "debug": "2.6.9",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "url-join": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
+          "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc="
+        }
       }
     },
     "http-signature": {
@@ -1947,8 +1963,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multimatch": {
       "version": "2.1.0",
@@ -2204,15 +2219,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
-    },
-    "portfinder": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
-      "integrity": "sha1-o/+t/6/k+5jgYBqF7aJ8J86Eyh4=",
-      "requires": {
-        "async": "0.9.0",
-        "mkdirp": "0.5.1"
-      }
     },
     "postcss": {
       "version": "5.2.18",
@@ -2870,11 +2876,6 @@
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
-    },
-    "url-join": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-parse": {
       "version": "1.0.5",


### PR DESCRIPTION
For posterity, "fixed" this by running `nvm use 8 && npm install`