### PR TITLE
Closes #278 Hides demo link when some video is playing

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -280,9 +280,13 @@ var ZenPlayer = {
     },
     show: function() {
         $("#audioplayer").show();
+        // Hide the demo link as some video is playing
+        $("#demo").hide();
     },
     hide: function() {
         $("#audioplayer").hide();
+        // Show the demo link as no video is playing
+        $("#demo").show();
     },
     setupTitle: function() {
         // Prepend music note only if title does not already begin with one.
@@ -681,10 +685,6 @@ $(function() {
         }
     });
 
-    // Hide the demo link if playing any of the demo video's audio
-    if ($.inArray(currentVideoID, demos) !== -1) {
-        $("#demo").hide();
-    }
 
     // Reverts to Home when there is no text in input
     $("#v").on("input", function() {


### PR DESCRIPTION
### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)


### Description
[ZenPlayer.show()](https://github.com/zen-audio-player/zen-audio-player.github.io/blob/master/js/everything.js#L281) is called to show the player (some video is playing) and [ZenPlayer.hide()](https://github.com/zen-audio-player/zen-audio-player.github.io/blob/master/js/everything.js#L284) is called to hide the player (no video is playing). So, updated the these functions to hide/show the demo button.
 
### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [ ] All tests passed.