### PR TITLE
Closes #278 While playing a song, hide the click for demo button

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -682,7 +682,7 @@ $(function() {
     });
 
     // Hide the demo link if playing any of the demo video's audio
-    if ($.inArray(currentVideoID, demos) !== -1) {
+    if ($.inArray(currentVideoID, demos) !== -1 || ZenPlayer.isPlaying) {
         $("#demo").hide();
     }
 


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [X ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [X] Describe your changes in detail.
- the demo button is currently hidden while demo is playing. I add the condition that if any audio is playing the button will be hidden.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [ ] All tests passed.
-->