### PR TITLE
Add Snyk to Travis

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.12.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:qs:20170213':
+    - http-server > union > qs:
+        reason: 'No Patch or Upgrade available '
+        expires: '2018-11-12T10:52:02.751Z'
+patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
+#env:
+#    - SNYK_TOKEN
+install:
+    - npm install
+after_success:
+    - snyk monitor
+cache:
+  directories:
+  - "$HOME/.npm"
 notifications:
   email: false
   webhooks:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://travis-ci.org/zen-audio-player/zen-audio-player.github.io.svg?branch=master)](https://travis-ci.org/zen-audio-player/zen-audio-player.github.io)
 [![Code Climate](https://codeclimate.com/github/zen-audio-player/zen-audio-player.github.io/badges/gpa.svg)](https://codeclimate.com/github/zen-audio-player/zen-audio-player.github.io)
 [![Issue Count](https://codeclimate.com/github/zen-audio-player/zen-audio-player.github.io/badges/issue_count.svg)](https://codeclimate.com/github/zen-audio-player/zen-audio-player.github.io)
+[![Known Vulnerabilities](https://snyk.io/test/github/zen-audio-player/zen-audio-player.github.io/badges/badge.svg)](https://snyk.io/test/github/zen-audio-player/zen-audio-player.github.io/badges)
 
 Listen to YouTube videos, without the distracting visuals.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "stylelint:css": "stylelint css/*.css",
     "lint": "npm run lint:js && npm run lint:html && npm run lint:css && npm run lint:tests",
     "pretest": "npm run stylelint:css && npm run lint",
-    "test": "mocha",
+    "test": "snyk test && mocha",
     "exp-fix:js": "eslint js/everything.js --fix",
     "start": "http-server --cors -o -a localhost"
   },
@@ -37,7 +37,8 @@
     "htmlhint": "^0.10.1",
     "mocha": "^5.2.0",
     "stylelint": "^9.5.0",
-    "zombie": "^6.1.3"
+    "zombie": "^6.1.3",
+    "snyk": "^1.103.4"
   },
   "engines": {
     "node": ">=8.x"


### PR DESCRIPTION
closes https://github.com/zen-audio-player/zen-audio-player.github.io/issues/299
- Adds Snyk vuln badge to the Readme.md
- I added npm install script because lock files needs to be regenerated for the updated packages.
- the `qs` package of `http-server` was introducing a high sever vuln, but there was no upgrade and no patch available so I added it to the skip in `.snyk` profile so the tests can pass. 
- Added snyk monitor for snapshot of last successful passed build.

### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [x] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.