### PR TITLE
Add support for 'time_continue' query string parameter

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -586,9 +586,8 @@ $(function() {
         var formValue = $.trim($("#v").val());
         var formValueTime = /[?&](t|time_continue)=(\d+)/g.exec(formValue);
         if (formValueTime && formValueTime.length > 2) {
+            formValue = formValue.replace(formValueTime[0], "");
             formValueTime = parseInt(formValueTime[2], 10);
-            formValue = formValue.replace(/[?&]t=\d*/g, "");
-            formValue = formValue.replace(/[?&]time_continue=\d*/g, "");
         }
         if (formValue) {
             var videoID = wrapParseYouTubeVideoID(formValue, true);

--- a/js/everything.js
+++ b/js/everything.js
@@ -584,16 +584,11 @@ $(function() {
     $("#form").submit(function(event) {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
-        var formValueTime = /[?&]t=(\d+)|[?&]time_continue=(\d+)/g.exec(formValue);
+        var formValueTime = /[?&](t|time_continue)=(\d+)/g.exec(formValue);
         if (formValueTime && formValueTime.length > 2) {
-            if (typeof formValueTime[1] !== "undefined") {
-                formValueTime = parseInt(formValueTime[1], 10);
-            }
-            else {
-                formValueTime = parseInt(formValueTime[2], 10);
-            }
-            formValue = formValue.replace(/[?&]t=\d+/g, "");
-            formValue = formValue.replace(/[?&]time_continue=\d+/g, "");
+            formValueTime = parseInt(formValueTime[2], 10);
+            formValue = formValue.replace(/[?&]t=\d*/g, "");
+            formValue = formValue.replace(/[?&]time_continue=\d*/g, "");
         }
         if (formValue) {
             var videoID = wrapParseYouTubeVideoID(formValue, true);

--- a/js/everything.js
+++ b/js/everything.js
@@ -584,15 +584,16 @@ $(function() {
     $("#form").submit(function(event) {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
-        var formValueTime = /[?&]t=(\d*)/g.exec(formValue);
-        var formValueTimeContinue = /[?&]time_continue=(\d*)/g.exec(formValue);
-        if (formValueTime && formValueTime.length > 1) {
-            formValueTime = parseInt(formValueTime[1], 10);
-            formValue = formValue.replace(/&t=\d*$/g, "");
-        }
-        if (formValueTimeContinue && formValueTimeContinue.length > 1) {
-            formValueTimeContinue = parseInt(formValueTimeContinue[1], 10);
-            formValue = formValue.replace(/&time_continue=\d*$/g, "");
+        var formValueTime = /[?&]t=(\d+)|[?&]time_continue=(\d+)/g.exec(formValue);
+        if (formValueTime && formValueTime.length > 2) {
+            if (typeof formValueTime[1] !== "undefined") {
+                formValueTime = parseInt(formValueTime[1], 10);
+            }
+            else {
+                formValueTime = parseInt(formValueTime[2], 10);
+            }
+            formValue = formValue.replace(/[?&]t=\d+/g, "");
+            formValue = formValue.replace(/[?&]time_continue=\d+/g, "");
         }
         if (formValue) {
             var videoID = wrapParseYouTubeVideoID(formValue, true);
@@ -616,7 +617,7 @@ $(function() {
                             window.location.href = makeSearchURL(formValue);
                         }
                         else {
-                            window.location.href = makeListenURL(videoID, formValueTime || formValueTimeContinue);
+                            window.location.href = makeListenURL(videoID, formValueTime);
                         }
                     }
                 }).fail(function(jqXHR, textStatus, errorThrown) {

--- a/js/everything.js
+++ b/js/everything.js
@@ -372,8 +372,12 @@ function getCurrentVideoID() {
  */
 function getCurrentTimePosition() {
     var t = parseInt(URI(window.location).search(true).t, 10);
+    var timeContinue = parseInt(URI(window.location).search(true).time_continue, 10);
     if (t > 0 && t < Number.MAX_VALUE) {
         return t;
+    }
+    else if (timeContinue > 0 && timeContinue < Number.MAX_VALUE) {
+        return timeContinue;
     }
     return 0;
 }
@@ -581,9 +585,14 @@ $(function() {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
         var formValueTime = /[?&]t=(\d*)/g.exec(formValue);
+        var formValueTimeContinue = /[?&]time_continue=(\d*)/g.exec(formValue);
         if (formValueTime && formValueTime.length > 1) {
             formValueTime = parseInt(formValueTime[1], 10);
             formValue = formValue.replace(/&t=\d*$/g, "");
+        }
+        if (formValueTimeContinue && formValueTimeContinue.length > 1) {
+            formValueTimeContinue = parseInt(formValueTimeContinue[1], 10);
+            formValue = formValue.replace(/&time_continue=\d*$/g, "");
         }
         if (formValue) {
             var videoID = wrapParseYouTubeVideoID(formValue, true);
@@ -607,7 +616,7 @@ $(function() {
                             window.location.href = makeSearchURL(formValue);
                         }
                         else {
-                            window.location.href = makeListenURL(videoID, formValueTime);
+                            window.location.href = makeListenURL(videoID, formValueTime || formValueTimeContinue);
                         }
                     }
                 }).fail(function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
### Motivation and Context
- [x] Why is this change required? What problem does it solve?
It adds support of 'time_continue' query string parameter. Fixes #301 .
- [x] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.
Done.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.
Add support for 'time_continue' query string parameter. 'time_continue' parameter behaves same as already supported 't' parameter.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.