### PR TITLE
Closes #222 Autoplay the next related video

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
                 <button class="btn" id="toggleDescription">
                     Show Description
                 </button>
+                <button class="btn" id="toggleAutoplay">
+                    Autoplay
+                </button>
                 <button class="btn" id="toggleRepeat">
                     Repeat Track
                 </button>

--- a/js/everything.js
+++ b/js/everything.js
@@ -304,15 +304,13 @@ var ZenPlayer = {
                 autoplayState = true;
                 toggleTextElement.text("Stop autoplay");
             }
-            else {
-                if (autoplayState === true) {
+            else if (autoplayState === true) {
                     toggleTextElement.text("Start autoplay");
                     autoplayState = false;
-                }
-                else {
-                    toggleTextElement.text("Stop autoplay");
-                    autoplayState = true;
-                }
+            }
+            else {
+                toggleTextElement.text("Stop autoplay");
+                autoplayState = true;
             }
         });
     },

--- a/js/everything.js
+++ b/js/everything.js
@@ -305,8 +305,8 @@ var ZenPlayer = {
                 toggleTextElement.text("Stop autoplay");
             }
             else if (autoplayState === true) {
-                    toggleTextElement.text("Start autoplay");
-                    autoplayState = false;
+                toggleTextElement.text("Start autoplay");
+                autoplayState = false;
             }
             else {
                 toggleTextElement.text("Stop autoplay");

--- a/js/everything.js
+++ b/js/everything.js
@@ -15,6 +15,11 @@ var plyrPlayer;
 var youTubeDataApiKey = "AIzaSyCxVxsC5k46b8I-CLXlF3cZHjpiqP_myVk";
 var currentVideoID;
 
+// global playlist, this is populated with an ajax call
+var playList = [];
+var autoplayState = false;
+var videoMetadata = {};
+
 var errorMessage = {
     init: function() {
         // nothing for now
@@ -137,6 +142,7 @@ var ZenPlayer = {
                 that.setupTitle();
                 that.setupVideoDescription(videoID);
                 that.setupPlyrToggle();
+                that.setupAutoplayToggle();
             });
 
             plyrPlayer.addEventListener("playing", function() {
@@ -163,6 +169,38 @@ var ZenPlayer = {
                 // Show player
                 that.show();
                 updateTweetMessage();
+            });
+
+            // when player has finished playing
+            plyrPlayer.addEventListener("ended", function() {
+                videoMetadata = getParsedVideoMetadata();
+                if (videoMetadata) {
+                    var isInItems = false;
+                    for (var i = 0; i < videoMetadata["items"].length; i++) {
+                        if (videoMetadata["items"][i]["id"] === currentVideoID) {
+                            isInItems = true;
+                        }
+                    }
+                    if (!isInItems) {
+                        videoMetadata["items"].push({"type": "youtube", "id": currentVideoID, "played": true });
+                    }
+                    videoMetadata["autoplayState"] = autoplayState;
+                }
+                else {
+                    videoMetadata = {
+                        "autoplayState": autoplayState,
+                        "items": [{
+                            "type": "youtube",
+                            "id": currentVideoID,
+                            "played": true
+                        }]
+                    };
+                }
+                window.sessionStorage.setItem("videoMetadata", JSON.stringify(videoMetadata));
+                if (autoplayState) {
+                    var newId = getNewVideoID();
+                    that.playNext(newId);
+                }
             });
 
             plyrPlayer.addEventListener("timeupdate", function() {
@@ -218,6 +256,11 @@ var ZenPlayer = {
             });
         }
     },
+    // play next song from autoplay
+    playNext: function(videoID) {
+        $("#v").val(videoID);
+        $("#form").submit();
+    },
     show: function() {
         $("#audioplayer").show();
         // Hide the demo link as some video is playing
@@ -251,6 +294,26 @@ var ZenPlayer = {
         // Show player button click event
         $("#togglePlayer").click(function(event) {
             toggleElement(event, ".plyr__video-wrapper", "Player");
+        });
+    },
+    setupAutoplayToggle: function() {
+        // toggle auto next song playing
+        $("#toggleAutoplay").click(function(event) {
+            var toggleTextElement = $("#" + event.currentTarget.id);
+            if (!autoplayState) {
+                autoplayState = true;
+                toggleTextElement.text("Stop autoplay");
+            }
+            else {
+                if (autoplayState === true) {
+                    toggleTextElement.text("Start autoplay");
+                    autoplayState = false;
+                }
+                else {
+                    toggleTextElement.text("Stop autoplay");
+                    autoplayState = true;
+                }
+            }
         });
     },
     getVideoDescription: function(videoID) {
@@ -519,6 +582,37 @@ function pickDemo() {
     return demos[Math.floor(Math.random() * demos.length)];
 }
 
+function updateAutoplayToggle(state) {
+    if (state) {
+        $("#toggleAutoplay").text("Stop autoplay");
+    }
+    else {
+        $("#toggleAutoplay").text("Start autoplay");
+    }
+}
+
+function getParsedVideoMetadata() {
+    videoMetadata = window.sessionStorage.getItem("videoMetadata");
+    if (videoMetadata) {
+        videoMetadata = JSON.parse(videoMetadata);
+    }
+    return videoMetadata;
+}
+
+function getNewVideoID() {
+    var nextID = null;
+    nextID = playList.pop();
+    for (var i = 0; i < videoMetadata["items"].length && nextID; i++) {
+        var curVideo = videoMetadata["items"][i];
+        if (curVideo["id"] === nextID) {
+            // restart the for loop
+            nextID = playList.pop();
+            i = -1;
+        }
+    }
+    return nextID;
+}
+
 $(function() {
     if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
         $("#container").hide();
@@ -529,11 +623,43 @@ $(function() {
 
     errorMessage.init();
 
+    videoMetadata = getParsedVideoMetadata();
+
+    if (videoMetadata) {
+        autoplayState = videoMetadata["autoplayState"];
+    }
+    if (autoplayState) {
+        updateAutoplayToggle(autoplayState);
+    }
+
     // How do we know if the value is truly invalid?
     // Preload the form from the URL
     var currentVideoID = getCurrentVideoID();
     if (currentVideoID) {
         $("#v").attr("value", currentVideoID);
+        // get similar videos, populate playList
+        if (!isFileProtocol()) {
+            $.ajax({
+                url: "https://www.googleapis.com/youtube/v3/search",
+                dataType: "json",
+                async: false,
+                data: {
+                    key: youTubeDataApiKey,
+                    part: "snippet",
+                    type: "video",
+                    relatedToVideoId: currentVideoID
+                },
+                success: function(data) {
+                    // push items into playlist
+                    for (var i = 0; i < data.items.length; i++) {
+                        playList.push(data.items[i].id.videoId);
+                    }
+                    playList = playList.reverse();
+                }
+            }).fail(function(jqXHR, textStatus, errorThrown) {
+                logError(jqXHR, textStatus, errorThrown, "Related video lookup error");
+            });
+        }
     }
     else {
         var currentSearchQuery = getCurrentSearchQuery();

--- a/js/everything.js
+++ b/js/everything.js
@@ -649,10 +649,9 @@ $(function() {
                 },
                 success: function(data) {
                     // push items into playlist
-                    for (var i = 0; i < data.items.length; i++) {
+                    for (var i = data.items.length - 1; i > -1; i--) {
                         playList.push(data.items[i].id.videoId);
                     }
-                    playList = playList.reverse();
                 }
             }).fail(function(jqXHR, textStatus, errorThrown) {
                 logError(jqXHR, textStatus, errorThrown, "Related video lookup error");


### PR DESCRIPTION
### Motivation and Context
This pull request fixes the bug where it would autoplay whatever was in the search box, but might lead to search results in PR #258 . It uses code from PR #231 and #258.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
Fixes PR #258 bug that autoplays the next query in the search box.
Instead, the next song that is related plays instead.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [x] All tests passed.
