### PR TITLE
fix height of input and search button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -199,6 +199,7 @@ a {
 
 .btn-search {
     width: 50px;
+    height: 30px;
 }
 
 @media all and (min-width: 480px) {
@@ -215,6 +216,13 @@ a {
         font-size: 20px;
     }
 
+}
+
+@media all and (max-width: 480px) {
+
+    .input-search {
+        height: 30px;
+    }
 }
 
 .sponsor {

--- a/css/styles.css
+++ b/css/styles.css
@@ -199,7 +199,6 @@ a {
 
 .btn-search {
     width: 50px;
-    height: 30px;
 }
 
 @media all and (min-width: 480px) {
@@ -221,6 +220,10 @@ a {
 @media all and (max-width: 480px) {
 
     .input-search {
+        height: 30px;
+    }
+
+    .btn-search {
         height: 30px;
     }
 }


### PR DESCRIPTION
### Motivation and Context
This pull request fixes the bug about issue #344 .
The buttons and input sizes were different in sizes smaller than 480px.
So I set the height of input and button to 30px  by using media query 
when window height is smaller than 480px.

### current behavior

![image](https://user-images.githubusercontent.com/38170596/70905784-1af1a680-2048-11ea-98c2-bb06c995a370.png)


### new behavior

![image](https://user-images.githubusercontent.com/38170596/70905731-f5fd3380-2047-11ea-8a81-d0f66b096ebc.png)



### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [] All tests passed.
