### PR TITLE
Add rel "preconnect" to font-awesome CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
     <script src="js/zap-common.js"></script>
     <script src="js/everything.js"></script>
     <script src="bower_components/plyr/dist/plyr.js"></script>
+
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-62983413-1"></script>
     <script>


### PR DESCRIPTION
### Motivation and Context
This change reduces loadtime by sending a earlier request to CDN resource.
### Types of changes
This should be non-breaking.
### Description
This change adds preconnect to the link stylesheet to speed up font downloading, the font is downloaded externally from a ContentDeliveryNetwork. the rel="" attribute accepts a space seperated list for this.
### Final checklist:
Codestyle is followed
I read the contributing.md file
The tests failed for some reason, not caused by me.