### PR TITLE
Preload stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
     <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon">
     <link rel="icon" href="img/favicon.ico" type="image/x-icon">
 
-    <link rel="stylesheet" href="bower_components/primer-css/css/primer.css">
-    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="bower_components/plyr/dist/plyr.css">
-    <link rel="stylesheet" href="css/styles.css">
+    <link rel="preload stylesheet" as="style" href="bower_components/primer-css/css/primer.css">
+    <link rel="preload stylesheet" as="style" href="bower_components/font-awesome/css/font-awesome.min.css">
+    <link rel="preload stylesheet" as="style" href="bower_components/plyr/dist/plyr.css">
+    <link rel="preload stylesheet" as="style" href="css/styles.css">
 
 
     <script type="text/javascript">window._trackJs = { token: "f58d0b7c4b4248939fddc582f9e55c9d" };</script>


### PR DESCRIPTION
### Motivation and Context

Removes renderblocking for faster initial page render.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

This change adds preload to `<link>` css, this is called asynchronous rendering and removes renderblocking. It should start showing the page as soon as possible.

The file should go from this `<link rel="stylesheet" href="styles/main.css">` to this `<link rel="preload stylesheet" as="style" href="styles/main.css">`


i tested the changes of #380 and #381 together in edge, firefox and chromium. Chrome reports no renderblocking

Requesting label: hacktoberfest-accepted
I was hoping to get label applied to previous PR #378 i forgot to ask.