### PR TITLE
add missing script async

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
 
 
     <script type="text/javascript">window._trackJs = { token: "f58d0b7c4b4248939fddc582f9e55c9d" };</script>
-    <script async src="bower_components/trackjs/tracker.js"></script>
+    <script src="bower_components/trackjs/tracker.js"></script>
     <script src="bower_components/jquery/dist/jquery.min.js"></script>
     <script src="bower_components/seiyria-bootstrap-slider/dist/bootstrap-slider.min.js"></script>
-    <script async src="bower_components/typeahead.js/dist/typeahead.jquery.min.js"></script>
+    <script src="bower_components/typeahead.js/dist/typeahead.jquery.min.js"></script>
     <script async src="bower_components/urijs/src/URI.min.js"></script>
     <script src="js/zap-common.js"></script>
     <script src="js/everything.js"></script>


### PR DESCRIPTION
### Motivation and Context

Adds missing async to rest of the external `<script src=#>` 's like so `<script async src=#>` 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description

This change makes rest of the javascript load asynchronously. Removes renderblocking, will render soonest possible.
This is a possible breaking change, i tested the changes of #380 and #381 together in edge, firefox and chromium. I see no issues and chrome reports no renderblocking, since there is a lot of javascript i cannot be sure it is non-breaking.

Requesting label: hacktoberfest-accepted
I was hoping to get label applied to previous PR #378 i forgot to ask.