### PR TITLE
Provide community favorites shortcut

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -141,11 +141,20 @@ a {
     display: block;
     margin: 0 auto;
 }
-
-#focus-btn {
+#com-fav-btn {
+    display: flex;
+    justify-content: center;
+}
+#fav-btn {
     display: block;
     margin: 0 auto;
     width: fit-content;
+}
+#focus-btn, #lofi-btn  {
+    margin-right: 5px;
+    width: fit-content;
+    text-align: center;
+    display: none;
 }
 
 #zen-video-description {

--- a/css/styles.css
+++ b/css/styles.css
@@ -141,16 +141,19 @@ a {
     display: block;
     margin: 0 auto;
 }
+
 #com-fav-btn {
     display: flex;
     justify-content: center;
 }
+
 #fav-btn {
     display: block;
     margin: 0 auto;
     width: fit-content;
 }
-#focus-btn, #lofi-btn  {
+
+#focus-btn, #lofi-btn {
     margin-right: 5px;
     width: fit-content;
     text-align: center;

--- a/index.html
+++ b/index.html
@@ -124,45 +124,44 @@
                     <i class="fa fa-headphones"></i>
                     Lofi
                 </button>
-                <div>
-                </div>
             </div>
-            <!-- footer -->
-            <footer>
-                <!-- Twitter hashtag button: #ZenAudioPlayer -->
-                <div id="tweetButton"></div>
-                <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? "http" : "https"; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + "://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
-                <!-- Attribution, and links -->
-                <div class="color-grey">
-                    <p>Created by <a href="https://twitter.com/_Shakeel" target="_blank">@_Shakeel</a> and <a
-                            href="https://github.com/zen-audio-player/zen-audio-player.github.io/graphs/contributors"
-                            target="_blank">others.</a></p>
-                    <p><a href="https://chrome.google.com/webstore/detail/zen-youtube-audio-player/jlkomkpeedajclllhhfkloddbihmcjlm"
-                            target="_blank">Get the Chrome extension</a> - (<a
-                            href="https://github.com/zen-audio-player/extension-chrome" target="_blank">source</a>)</p>
-                </div>
+        </div>
+    </div>
+    <!-- footer -->
+    <footer>
+        <!-- Twitter hashtag button: #ZenAudioPlayer -->
+        <div id="tweetButton"></div>
+        <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? "http" : "https"; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + "://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
+        <!-- Attribution, and links -->
+        <div class="color-grey">
+            <p>Created by <a href="https://twitter.com/_Shakeel" target="_blank">@_Shakeel</a> and <a
+                    href="https://github.com/zen-audio-player/zen-audio-player.github.io/graphs/contributors"
+                    target="_blank">others.</a></p>
+            <p><a href="https://chrome.google.com/webstore/detail/zen-youtube-audio-player/jlkomkpeedajclllhhfkloddbihmcjlm"
+                    target="_blank">Get the Chrome extension</a> - (<a
+                    href="https://github.com/zen-audio-player/extension-chrome" target="_blank">source</a>)</p>
+        </div>
 
-                <br>
+        <br>
 
-                <!-- Sponsor links -->
-                <h3>Sponsored by:</h3>
-                <div class="sponsor">
-                    <a href="https://trackjs.com/" class="sponsor-a" target="_blank">
-                        <img src="img/trackjs_logo.png" alt="TrackJS Logo" class="img-40">
-                    </a>
-                    <div class="clear-both"></div>
-                </div>
+        <!-- Sponsor links -->
+        <h3>Sponsored by:</h3>
+        <div class="sponsor">
+            <a href="https://trackjs.com/" class="sponsor-a" target="_blank">
+                <img src="img/trackjs_logo.png" alt="TrackJS Logo" class="img-40">
+            </a>
+            <div class="clear-both"></div>
+        </div>
 
-                <!-- social media icons -->
-                <div class="repo-info">
-                    <br>
-                    <p>Source available on GitHub: <br><a
-                            href="https://github.com/zen-audio-player/zen-audio-player.github.io" class="fa fa-github"
-                            target="_blank"></a></p>
-                </div>
-            </footer>
-            <!-- Schema.org structured data -->
-            <script type="application/ld+json">
+        <!-- social media icons -->
+        <div class="repo-info">
+            <br>
+            <p>Source available on GitHub: <br><a href="https://github.com/zen-audio-player/zen-audio-player.github.io"
+                    class="fa fa-github" target="_blank"></a></p>
+        </div>
+    </footer>
+    <!-- Schema.org structured data -->
+    <script type="application/ld+json">
         {
             "@context": "http://schema.org",
             "@type": "Organization",

--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script src="https://www.googletagmanager.com/gtag/js?id=UA-62983413-1"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag("js", new Date());
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag("js", new Date());
 
-      gtag("config", "UA-62983413-1");
-      gtag("send", "pageview");
+        gtag("config", "UA-62983413-1");
+        gtag("send", "pageview");
     </script>
 
     <script src="js/zap-common.js"></script>
@@ -110,47 +110,59 @@
 
         <div>
             <br>
-            <button class="btn" id="focus-btn">
+            <button class="btn" id="fav-btn">
                 <i class="fa fa-headphones"></i>
-                Focus
+                Community favorites
             </button>
-        </div>
-    </div>
-    <!-- footer -->
-    <footer>
-        <!-- Twitter hashtag button: #ZenAudioPlayer -->
-        <div id="tweetButton"></div>
-        <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? "http" : "https"; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + "://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
-        <!-- Attribution, and links -->
-        <div class="color-grey">
-            <p>Created by <a href="https://twitter.com/_Shakeel" target="_blank">@_Shakeel</a> and <a
-                    href="https://github.com/zen-audio-player/zen-audio-player.github.io/graphs/contributors"
-                    target="_blank">others.</a></p>
-            <p><a href="https://chrome.google.com/webstore/detail/zen-youtube-audio-player/jlkomkpeedajclllhhfkloddbihmcjlm"
-                    target="_blank">Get the Chrome extension</a> - (<a
-                    href="https://github.com/zen-audio-player/extension-chrome" target="_blank">source</a>)</p>
-        </div>
-
-        <br>
-
-        <!-- Sponsor links -->
-        <h3>Sponsored by:</h3>
-        <div class="sponsor">
-            <a href="https://trackjs.com/" class="sponsor-a" target="_blank">
-                <img src="img/trackjs_logo.png" alt="TrackJS Logo" class="img-40">
-            </a>
-            <div class="clear-both"></div>
-        </div>
-
-        <!-- social media icons -->
-        <div class="repo-info">
             <br>
-            <p>Source available on GitHub: <br><a href="https://github.com/zen-audio-player/zen-audio-player.github.io"
-                    class="fa fa-github" target="_blank"></a></p>
-        </div>
-    </footer>
-    <!-- Schema.org structured data -->
-    <script type="application/ld+json">
+            <div id="com-fav-btn">
+                <button class="btn" id="focus-btn">
+                    <i class="fa fa-headphones"></i>
+                    Focus
+                </button>
+                <button class="btn" id="lofi-btn">
+                    <i class="fa fa-headphones"></i>
+                    Lofi
+                </button>
+                <div>
+                </div>
+            </div>
+            <!-- footer -->
+            <footer>
+                <!-- Twitter hashtag button: #ZenAudioPlayer -->
+                <div id="tweetButton"></div>
+                <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? "http" : "https"; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + "://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
+                <!-- Attribution, and links -->
+                <div class="color-grey">
+                    <p>Created by <a href="https://twitter.com/_Shakeel" target="_blank">@_Shakeel</a> and <a
+                            href="https://github.com/zen-audio-player/zen-audio-player.github.io/graphs/contributors"
+                            target="_blank">others.</a></p>
+                    <p><a href="https://chrome.google.com/webstore/detail/zen-youtube-audio-player/jlkomkpeedajclllhhfkloddbihmcjlm"
+                            target="_blank">Get the Chrome extension</a> - (<a
+                            href="https://github.com/zen-audio-player/extension-chrome" target="_blank">source</a>)</p>
+                </div>
+
+                <br>
+
+                <!-- Sponsor links -->
+                <h3>Sponsored by:</h3>
+                <div class="sponsor">
+                    <a href="https://trackjs.com/" class="sponsor-a" target="_blank">
+                        <img src="img/trackjs_logo.png" alt="TrackJS Logo" class="img-40">
+                    </a>
+                    <div class="clear-both"></div>
+                </div>
+
+                <!-- social media icons -->
+                <div class="repo-info">
+                    <br>
+                    <p>Source available on GitHub: <br><a
+                            href="https://github.com/zen-audio-player/zen-audio-player.github.io" class="fa fa-github"
+                            target="_blank"></a></p>
+                </div>
+            </footer>
+            <!-- Schema.org structured data -->
+            <script type="application/ld+json">
         {
             "@context": "http://schema.org",
             "@type": "Organization",

--- a/js/everything.js
+++ b/js/everything.js
@@ -511,6 +511,8 @@ function wrapParseYouTubeVideoID(url) {
 
 // The focus video ID
 var focusId = "pJ5FD9_Orbg";
+// The lofi video ID
+var lofiId = "5qap5aO4i9A";
 
 // Some demo video's audio, feel free to add more
 var demos = [
@@ -667,6 +669,12 @@ $(function() {
         }
     });
 
+    //Handle community favorites click
+    $("#fav-btn").click(function(event) {
+        $( "#focus-btn" ).toggle();
+        $( "#lofi-btn" ).toggle();
+    })
+
     // Handle focus link click
     $("#focus-btn").click(function(event) {
         event.preventDefault();
@@ -675,15 +683,27 @@ $(function() {
         window.location.href = makeListenURL(focusId);
     });
 
-    // Check if the current ID is the focus ID
+    // Handle lofi link click
+    $("#lofi-btn").click(function(event) {
+        event.preventDefault();
+        gtag("send", "event", "lofi", "clicked");
+        // Redirect to the favorite "lofi" URL
+        window.location.href = makeListenURL(lofiId);
+    });
+
+    // Check if the current ID is the community focus ID
     $(window).on("load", function() {
         // Show Focus Button
         if (window.location.href.indexOf(focusId) === -1) {
-            $("#focus-btn").show();
+            $("#fav-btn").show();
+        }
+        // Show Lofi Button
+        else if (window.location.href.indexOf(d) === -1){
+            $("#fav-btn").show();
         }
         else {
-            // Hide Focus Button
-            $("#focus-btn").hide();
+            // Hide community favorites Button
+            $("#fav-btn").hide();
         }
     });
 

--- a/js/everything.js
+++ b/js/everything.js
@@ -669,11 +669,12 @@ $(function() {
         }
     });
 
-    //Handle community favorites click
+    // Handle community favorites click
     $("#fav-btn").click(function(event) {
+        event.preventDefault();
         $( "#focus-btn" ).toggle();
         $( "#lofi-btn" ).toggle();
-    })
+    });
 
     // Handle focus link click
     $("#focus-btn").click(function(event) {
@@ -698,7 +699,7 @@ $(function() {
             $("#fav-btn").show();
         }
         // Show Lofi Button
-        else if (window.location.href.indexOf(d) === -1){
+        else if (window.location.href.indexOf(lofiId) === -1) {
             $("#fav-btn").show();
         }
         else {
@@ -706,7 +707,6 @@ $(function() {
             $("#fav-btn").hide();
         }
     });
-
 
     // Load the player
     ZenPlayer.init(currentVideoID);


### PR DESCRIPTION
### Motivation and Context
This adds a generalized concept of community favorites, which includes the existing focus shortcut and the new lofi girl shortcut.
Closes #374 (Add shortcuts for "community favorites")

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
This change adds a shortcut for community favorites as a general concept, clicking it makes appear a shortcut for focus and a shortcut for lofi. Tested it on Safari and Chrome.
<img width="1440" alt="Screen Shot 2021-12-26 at 11 56 36" src="https://user-images.githubusercontent.com/58761246/147417494-a70fc42d-f129-4c01-857d-9965ada54f0c.png">

### Final checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [X] All tests passed.