### PR TITLE
CI: Increase demo test timeout to 5s

### DIFF
--- a/test/demo.js
+++ b/test/demo.js
@@ -4,7 +4,7 @@ const puppeteer = require("puppeteer");
 const http = require("http-server");
 
 const SERVER_PORT = 8000;
-const TEST_TIMEOUT = 4000;
+const TEST_TIMEOUT = 5000;
 const indexHTMLURL = `http://localhost:${SERVER_PORT}/index.html`;
 let server;
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request increases the timeout for demo tests from 4 seconds to 5 seconds to ensure tests have sufficient time to complete.

- **CI**:
    - Increased the demo test timeout from 4 seconds to 5 seconds to accommodate longer-running tests.

<!-- Generated by sourcery-ai[bot]: end summary -->