### PR TITLE
fix left-alignment with search results

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -103,10 +103,10 @@ footer .fa {
 
 .search-input {
     width: 100%;
-    padding-left: 50px;
+    padding-left: 24px;
     margin: 0 auto;
     font-size: 16px;
-    text-align: center;
+    text-align: left;
 }
 
 .search-input::-ms-clear {
@@ -138,7 +138,8 @@ footer .fa {
 }
 
 .tt-suggestion {
-    text-align: center;
+    padding-left: 24px;
+    text-align: left;
 }
 
 .tt-cursor,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "bun run lint:js && bun run lint:html && bun run lint:css && bun run lint:tests",
     "pretest": "bun run lint",
     "test": "bunx mocha",
-    "fix": "bunx eslint js/everything.js test/*.js --fix",
+    "fix": "bunx eslint js/everything.js test/*.js --fix && bunx stylelint css/*.css --fix",
     "fest": "bun run fix && bun run test",
     "start": "bunx http-server --cors -o -a localhost"
   },
@@ -35,7 +35,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
     "eslint": "^10.0.2",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "htmlhint": "^1.9.1",
     "http-server": "^14.1.1",
     "mocha": "^11.7.5",


### PR DESCRIPTION
## Summary by Sourcery

Align search input and typeahead suggestions to the left and extend lint-fix tooling to CSS while updating a dev dependency version.

Enhancements:
- Adjust search input and autocomplete suggestion styles to use left alignment with consistent padding.
- Expand the npm fix script to run stylelint auto-fixes on CSS files in addition to ESLint.
- Bump the globals development dependency to the latest minor version.